### PR TITLE
make .date font size relative

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -14,7 +14,7 @@ main {
 }
 
 .post > .date {
-	font-size: small;
+	font-size: 0.81em;
 }
 
 .label-text {


### PR DESCRIPTION
This makes the font size relative and allows people to specify a larger font size on body to make the entire text content larger uniformly.

0.81em is about equal to the previous font size. 0.8125 would be the exact one if the browser defaults to 16px font size and uses 13px for "small"